### PR TITLE
Fix: add path to moduls in tests

### DIFF
--- a/findoutlie/tests/test_detectors.py
+++ b/findoutlie/tests/test_detectors.py
@@ -13,12 +13,8 @@ from pathlib import Path
 import sys
 
 MY_DIR = Path(__file__).parent
-
-# Here you should add the directory containing the findoutlie
-# directory to the Python path.
-# Hint: sys.path
-# Hint: see the solutions if you are stuck.
-# +++your code here+++
+CODE_DIR = (MY_DIR / '..').absolute()
+sys.path.append(str(CODE_DIR))
 
 import numpy as np
 

--- a/findoutlie/tests/test_spm_funcs.py
+++ b/findoutlie/tests/test_spm_funcs.py
@@ -15,11 +15,8 @@ import sys
 MY_DIR = Path(__file__).parent
 EXAMPLE_FILENAME = 'ds107_sub012_t1r2_small.nii'
 
-# Here you should add the directory containing the findoutlie
-# directory to the Python path.
-# Hint: sys.path
-# Hint: see the solutions if you are stuck.
-# +++your code here+++
+CODE_DIR = (MY_DIR / '..').absolute()
+sys.path.append(str(CODE_DIR))
 
 import numpy as np
 


### PR DESCRIPTION
This should be temporary, in the future we do not want to use these hacks. 